### PR TITLE
Small default component to display error message 

### DIFF
--- a/components/errorboundary.jsx
+++ b/components/errorboundary.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+/**
+ * Default Error Boundary component
+ * This will catch unhandled error and displays an error message.
+ * You can customise it to show different messages depending on the errors.
+ */
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+      super(props)
+  
+      // Define a state variable to track whether is an error or not
+      this.state = { hasError: false }
+    }
+    static getDerivedStateFromError(error) {
+      // Update state so the next render will show the fallback UI
+  
+      return { hasError: true }
+    }
+    componentDidCatch(error, errorInfo) {
+      // You can use your own error logging service here
+      console.log({ error, errorInfo })
+    }
+    render() {
+      // Check if the error is thrown
+      if (this.state.hasError) {
+        // You can render any custom fallback UI
+        return (
+          <div>
+            <h2>Oops, there is an error!</h2>
+            <button
+              type="button"
+              onClick={() => this.setState({ hasError: false })}
+            >
+              Try again?
+            </button>
+          </div>
+        )
+      }
+  
+      // Return children components in case of no error
+  
+      return this.props.children
+    }
+  }
+  
+  export default ErrorBoundary

--- a/components/errorboundary.jsx
+++ b/components/errorboundary.jsx
@@ -28,12 +28,13 @@ class ErrorBoundary extends React.Component {
         return (
           <div>
             <h2>Oops, there is an error!</h2>
-            <button
+            {/* Add your own handling/retry here */}
+            {/* <button
               type="button"
               onClick={() => this.setState({ hasError: false })}
             >
               Try again?
-            </button>
+            </button> */}
           </div>
         )
       }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@
 import "../styles/globals.css"
 import React from 'react';
 import Layout from '../components/layout';
+import ErrorBoundary from '../components/errorboundary';
 import { Amplify } from "aws-amplify";
 import checkUser from '../helpers/checkUser';
 
@@ -23,7 +24,9 @@ function WebApp({ Component, pageProps }) {
   const user = checkUser();
   return (
         <Layout signedInUser={user}>
-          <Component {...pageProps} signedInUser={user} />
+          <ErrorBoundary>
+            <Component {...pageProps} signedInUser={user} />
+          </ErrorBoundary>
         </Layout>
   )
 }


### PR DESCRIPTION
Added error boundary to catch unhandled errors and ability to display custom error messages.

Just a better alternative to `Page is broken` - it's a base template to build on and add meaningful error to the user.