### PR TITLE
Fix for transparent header dropdown.

### DIFF
--- a/components/speakers/schedule.jsx
+++ b/components/speakers/schedule.jsx
@@ -166,7 +166,7 @@ function ScheduleStatic() {
 export default function Schedule() {
   return (
     <section id="schedule" aria-label="Schedule" className="py-20 sm:py-32">
-      <Container className="relative z-10">
+      <Container>
         <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-4xl lg:pr-24">
           <h2 className="font-display text-4xl font-medium tracking-tighter text-blue-600 sm:text-5xl">
             Our two day schedule is jam-packed with some of the smartest minds in the field of Data Engineering.


### PR DESCRIPTION
Do we need the z-index for something?

Frontend best practice is to avoid z-index at all cost unless it's truly necessary.

Before & after:
<img width="1083" alt="Screen Shot 2022-08-19 at 6 49 32 pm" src="https://user-images.githubusercontent.com/11097906/185584585-056256e6-bdb6-4383-9976-e078a53f8198.png">

<img width="1072" alt="Screen Shot 2022-08-19 at 6 49 40 pm" src="https://user-images.githubusercontent.com/11097906/185584566-96a5f361-8bf2-45a9-8f49-a70dd04b8065.png">
 