### PR TITLE
Feature/header reordering

### DIFF
--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -25,6 +25,12 @@ const aboutUs = [
     icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
+    name: "Blogs",
+    description: "Our awesome blogs!",
+    href: "/blogs",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
+  },
+  {
     name: "FAQs",
     description: "Answers to your questions!",
     href: "/faq",
@@ -241,12 +247,6 @@ export default function Navigation(props) {
                   </a>
                 ))}
                 <a
-                  href="/blogs"
-                  className="text-base font-medium text-gray-500 hover:text-gray-900"
-                >
-                  Blogs
-                </a>
-                <a
                   href="/sponsorship"
                   className="text-base font-medium text-gray-500 hover:text-gray-900"
                 >
@@ -330,12 +330,6 @@ export default function Navigation(props) {
                         {item.name}
                       </a>
                     ))}
-                    <a
-                      href="/blogs"
-                      className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    >
-                      Blogs
-                    </a>
                     <a
                       href="/sponsorship"
                       className="text-base font-medium text-gray-900 hover:text-gray-700"

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -1,108 +1,181 @@
 /* This example requires Tailwind CSS v2.0+ */
-import { Fragment, useState, useEffect } from 'react'
-import { Popover, Transition } from '@headlessui/react'
-import {
-  MenuIcon,
-  XIcon,
-} from '@heroicons/react/outline'
-import { ChevronDownIcon } from '@heroicons/react/solid'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faMeetup } from '@fortawesome/free-brands-svg-icons'
+import { Fragment, useState, useEffect } from "react";
+import { Popover, Transition } from "@headlessui/react";
+import { MenuIcon, XIcon } from "@heroicons/react/outline";
+import { ChevronDownIcon } from "@heroicons/react/solid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMeetup } from "@fortawesome/free-brands-svg-icons";
 
-import SignOut from '../components/auth/sign-out'
+import SignOut from "../components/auth/sign-out";
 
-const dataEngLogo = "/images/dataEngLogos/DataEng.MeetUp600x450.transparent.v1.png"
+const dataEngLogo =
+  "/images/dataEngLogos/DataEng.MeetUp600x450.transparent.v1.png";
 
 const aboutUs = [
   {
-    name: 'Our Team',
-    description: 'Find out about the brains behind the operation!',
-    href: '/team',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Our Team",
+    description: "Find out about the brains behind the operation!",
+    href: "/team",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Code of Conduct',
-    description: 'Lets create a safe space!',
-    href: '/conduct',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Code of Conduct",
+    description: "Lets create a safe space!",
+    href: "/conduct",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'FAQs',
-    description: 'Answers to your questions!',
-    href: '/faq',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "FAQs",
+    description: "Answers to your questions!",
+    href: "/faq",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Contact Us',
-    description: 'All the links of where to find us on the socials',
-    href: '/contact',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Contact Us",
+    description: "All the links of where to find us on the socials",
+    href: "/contact",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
-]
+];
 
 const conferenceLinks = [
   {
-    name: 'Speakers',
-    description: 'Our awesome speakers for 2022!',
-    href: '/conference/speakers',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Speakers",
+    description: "Our awesome speakers for 2022!",
+    href: "/conference/speakers",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Schedule',
-    description: 'Our awesome schedule for 2022!',
-    href: '/conference/schedule',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Schedule",
+    description: "Our awesome schedule for 2022!",
+    href: "/conference/schedule",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: '2020',
-    description: 'Our first ever conference!',
-    href: 'https://2020.dataengconf.com.au',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "2020",
+    description: "Our first ever conference!",
+    href: "https://2020.dataengconf.com.au",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: '2021',
-    description: 'DataEngBytes, the sequel!',
-    href: 'https://2021.dataengconf.com.au',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "2021",
+    description: "DataEngBytes, the sequel!",
+    href: "https://2021.dataengconf.com.au",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
-]
+];
 
 const meetupLinks = [
   {
-    name: 'Brisbane',
-    description: 'Learn from local data engineers in Brisbane.',
-    href: 'https://www.meetup.com/Brisbane-Data-Engineering-Meetup/',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Brisbane",
+    description: "Learn from local data engineers in Brisbane.",
+    href: "https://www.meetup.com/Brisbane-Data-Engineering-Meetup/",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Melbourne',
-    description: 'Find out who is doing the best data engineering in Melbourne.',
-    href: 'https://www.meetup.com/Melbourne-Data-Engineering-Meetup/',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Melbourne",
+    description:
+      "Find out who is doing the best data engineering in Melbourne.",
+    href: "https://www.meetup.com/Melbourne-Data-Engineering-Meetup/",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Perth',
-    description: 'Find out who is doing the best data engineering in Perth.',
-    href: 'https://www.meetup.com/Perth-Data-Engineering-Meetup/',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Perth",
+    description: "Find out who is doing the best data engineering in Perth.",
+    href: "https://www.meetup.com/Perth-Data-Engineering-Meetup/",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: 'Sydney',
-    description: 'See what companies are leading the field in data engineering in Sydney and beyond.',
-    href: 'https://www.meetup.com/Sydney-Data-Engineering-Meetup/',
-    icon: <FontAwesomeIcon icon={faMeetup} />
+    name: "Sydney",
+    description:
+      "See what companies are leading the field in data engineering in Sydney and beyond.",
+    href: "https://www.meetup.com/Sydney-Data-Engineering-Meetup/",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
   },
-]
+];
 
 function classNames(...classes) {
-  return classes.filter(Boolean).join(' ')
+  return classes.filter(Boolean).join(" ");
 }
 
+function NavbarItem(label, list) {
+  return (
+    <Popover className="relative">
+      {({ open }) => (
+        <>
+          <Popover.Button
+            className={classNames(
+              open ? "text-gray-900" : "text-gray-500",
+              "group bg-white rounded-md inline-flex items-center text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            )}
+          >
+            <span>{label}</span>
+
+            <ChevronDownIcon
+              className={classNames(
+                open ? "text-gray-600" : "text-gray-400",
+                "ml-2 h-5 w-5 group-hover:text-gray-500"
+              )}
+              aria-hidden="true"
+            />
+          </Popover.Button>
+
+          <Transition
+            show={open}
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <Popover.Panel
+              static
+              className="absolute z-10 left-1/2 transform -translate-x-1/2 mt-3 px-2 w-screen max-w-md sm:px-0"
+            >
+              <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
+                <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
+                  {list.map((item) => (
+                    <a
+                      key={item.name}
+                      href={item.href}
+                      className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
+                    >
+                      <div
+                        className="flex-shrink-0 h-6 w-6 text-indigo-600"
+                        aria-hidden="true"
+                      >
+                        {item.icon}
+                      </div>
+                      <div className="ml-4">
+                        {item.name && (
+                          <p className="text-base font-medium text-gray-900">
+                            {item.name}
+                          </p>
+                        )}
+                        {item.description && (
+                          <p className="mt-1 text-sm text-gray-500">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </Popover.Panel>
+          </Transition>
+        </>
+      )}
+    </Popover>
+  );
+}
 export default function Navigation(props) {
   // console.log('navbar props: ',props)
-  const signedInUser = props.signedInUser
-  const [status, setStatus] = useState('sign-in')
-  const [user, setUser] = useState(null)
+  const signedInUser = props.signedInUser;
+  const [status, setStatus] = useState("sign-in");
+  const [user, setUser] = useState(null);
   // useEffect(() => setStatus(useState('sign-in')), [])
   // useEffect(() => setUser(useState(null)), [])
 
@@ -122,216 +195,49 @@ export default function Navigation(props) {
                   />
                 </a>
               </div>
-                <div>
-            </div>
+              <div></div>
               <div className="-mr-2 -my-2 md:hidden">
                 <Popover.Button className="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
                   <span className="sr-only">Open menu</span>
                   <MenuIcon className="h-6 w-6" aria-hidden="true" />
                 </Popover.Button>
               </div>
-              
 
               <Popover.Group as="nav" className="hidden md:flex space-x-10">
-                
-              <Popover className="relative">
-                  {({ open }) => (
-                    <>
-                      <Popover.Button
-                        className={classNames(
-                          open ? 'text-gray-900' : 'text-gray-500',
-                          'group bg-white rounded-md inline-flex items-center text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-                        )}
-                      >
-                        <span>Conference</span>
-                        <ChevronDownIcon
-                          className={classNames(
-                            open ? 'text-gray-600' : 'text-gray-400',
-                            'ml-2 h-5 w-5 group-hover:text-gray-500'
-                          )}
-                          aria-hidden="true"
-                        />
-                      </Popover.Button>
-
-                      <Transition
-                        show={open}
-                        as={Fragment}
-                        enter="transition ease-out duration-200"
-                        enterFrom="opacity-0 translate-y-1"
-                        enterTo="opacity-100 translate-y-0"
-                        leave="transition ease-in duration-150"
-                        leaveFrom="opacity-100 translate-y-0"
-                        leaveTo="opacity-0 translate-y-1"
-                      >
-                        <Popover.Panel
-                          static
-                          className="absolute z-10 left-1/2 transform -translate-x-1/2 mt-3 px-2 w-screen max-w-md sm:px-0"
-                        >
-                          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-                            <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
-                              {conferenceLinks.map((item) => (
-                                <a
-                                  key={item.name}
-                                  href={item.href}
-                                  className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
-                                >
-                                  <div className="flex-shrink-0 h-6 w-6 text-indigo-600" aria-hidden="true">
-                                  {item.icon}
-                                  </div>
-                                  <div className="ml-4">
-                                    <p className="text-base font-medium text-gray-900">{item.name}</p>
-                                    <p className="mt-1 text-sm text-gray-500">{item.description}</p>
-                                  </div>
-                                </a>
-                              ))}
-                            </div>
-                          </div>
-                        </Popover.Panel>
-                      </Transition>
-                    </>
-                  )}
-                </Popover>
-
-                <a href="/blogs" className="text-base font-medium text-gray-500 hover:text-gray-900">
+                { NavbarItem("Conference", conferenceLinks) }
+                <a
+                  href="/blogs"
+                  className="text-base font-medium text-gray-500 hover:text-gray-900"
+                >
                   Blogs
                 </a>
-                <a href="/sponsorship" className="text-base font-medium text-gray-500 hover:text-gray-900">
+                <a
+                  href="/sponsorship"
+                  className="text-base font-medium text-gray-500 hover:text-gray-900"
+                >
                   Sponsor Us
                 </a>
-                <Popover className="relative">
-                  {({ open }) => (
-                    <>
-                      <Popover.Button
-                        className={classNames(
-                          open ? 'text-gray-900' : 'text-gray-500',
-                          'group bg-white rounded-md inline-flex items-center text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-                        )}
-                      >
-                        <span>About Us</span>
-                        <ChevronDownIcon
-                          className={classNames(
-                            open ? 'text-gray-600' : 'text-gray-400',
-                            'ml-2 h-5 w-5 group-hover:text-gray-500'
-                          )}
-                          aria-hidden="true"
-                        />
-                      </Popover.Button>
-
-                      <Transition
-                        show={open}
-                        as={Fragment}
-                        enter="transition ease-out duration-200"
-                        enterFrom="opacity-0 translate-y-1"
-                        enterTo="opacity-100 translate-y-0"
-                        leave="transition ease-in duration-150"
-                        leaveFrom="opacity-100 translate-y-0"
-                        leaveTo="opacity-0 translate-y-1"
-                      >
-                        <Popover.Panel
-                          static
-                          className="absolute z-10 left-1/2 transform -translate-x-1/2 mt-3 px-2 w-screen max-w-md sm:px-0"
-                        >
-                          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-                            <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
-                              {aboutUs.map((item) => (
-                                <a
-                                  key={item.name}
-                                  href={item.href}
-                                  className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
-                                >
-                                  <div className="flex-shrink-0 h-6 w-6 text-indigo-600" aria-hidden="true">
-                                  {item.icon}
-                                  </div>
-                                  <div className="ml-4">
-                                    <p className="text-base font-medium text-gray-900">{item.name}</p>
-                                    <p className="mt-1 text-sm text-gray-500">{item.description}</p>
-                                  </div>
-                                </a>
-                              ))}
-                            </div>
-                          </div>
-                        </Popover.Panel>
-                      </Transition>
-                    </>
-                  )}
-                </Popover>
-
-                <Popover className="relative">
-                  {({ open }) => (
-                    <>
-                      <Popover.Button
-                        className={classNames(
-                          open ? 'text-gray-900' : 'text-gray-500',
-                          'group bg-white rounded-md inline-flex items-center text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-                        )}
-                      >
-                        <span>Meetups</span>
-                        <ChevronDownIcon
-                          className={classNames(
-                            open ? 'text-gray-600' : 'text-gray-400',
-                            'ml-2 h-5 w-5 group-hover:text-gray-500'
-                          )}
-                          aria-hidden="true"
-                        />
-                      </Popover.Button>
-
-                      <Transition
-                        show={open}
-                        as={Fragment}
-                        enter="transition ease-out duration-200"
-                        enterFrom="opacity-0 translate-y-1"
-                        enterTo="opacity-100 translate-y-0"
-                        leave="transition ease-in duration-150"
-                        leaveFrom="opacity-100 translate-y-0"
-                        leaveTo="opacity-0 translate-y-1"
-                      >
-                        <Popover.Panel
-                          static
-                          className="absolute z-10 left-1/2 transform -translate-x-1/2 mt-3 px-2 w-screen max-w-md sm:px-0"
-                        >
-                          <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-                            <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
-                              {meetupLinks.map((item) => (
-                                <a
-                                  key={item.name}
-                                  href={item.href}
-                                  className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
-                                >
-                                  <div className="flex-shrink-0 h-6 w-6 text-indigo-600" aria-hidden="true">
-                                  {item.icon}
-                                  </div>
-                                  <div className="ml-4">
-                                    <p className="text-base font-medium text-gray-900">{item.name}</p>
-                                    <p className="mt-1 text-sm text-gray-500">{item.description}</p>
-                                  </div>
-                                </a>
-                              ))}
-                            </div>
-                          </div>
-                        </Popover.Panel>
-                      </Transition>
-                    </>
-                  )}
-                </Popover>
-
-              </Popover.Group>              
-             {signedInUser ? 
-              <>
-                <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
-                  <SignOut />
-                </div>
-              </> :
-              <>
-              <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
-                <a
-                  href="https://www.tickettailor.com/events/dataengbytes"
-                  className="ml-8 whitespace-nowrap inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700"
-                >
-                  Get Tickets
-                </a>
-              </div>
-
-              </>}
+                { NavbarItem("About Us", aboutUs) }
+                { NavbarItem("Meetups", meetupLinks) }
+              </Popover.Group>
+              {signedInUser ? (
+                <>
+                  <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
+                    <SignOut />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
+                    <a
+                      href="https://www.tickettailor.com/events/dataengbytes"
+                      className="ml-8 whitespace-nowrap inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+                    >
+                      Get Tickets
+                    </a>
+                  </div>
+                </>
+              )}
             </div>
           </div>
 
@@ -370,8 +276,6 @@ export default function Navigation(props) {
                 </div>
                 <div className="py-6 px-5 space-y-6">
                   <div className="grid grid-cols-2 gap-y-4 gap-x-8">
-
-
                     {conferenceLinks.map((item) => (
                       <a
                         key={item.name}
@@ -381,10 +285,16 @@ export default function Navigation(props) {
                         {item.name}
                       </a>
                     ))}
-                    <a href="/blogs" className="text-base font-medium text-gray-900 hover:text-gray-700">
+                    <a
+                      href="/blogs"
+                      className="text-base font-medium text-gray-900 hover:text-gray-700"
+                    >
                       Blogs
                     </a>
-                    <a href="/sponsorship" className="text-base font-medium text-gray-900 hover:text-gray-700">
+                    <a
+                      href="/sponsorship"
+                      className="text-base font-medium text-gray-900 hover:text-gray-700"
+                    >
                       Sponsor Us
                     </a>
                     {aboutUs.map((item) => (
@@ -396,7 +306,7 @@ export default function Navigation(props) {
                         {item.name}
                       </a>
                     ))}
-                    
+
                     {meetupLinks.map((item) => (
                       <a
                         key={item.name}
@@ -406,21 +316,21 @@ export default function Navigation(props) {
                         {item.name}
                       </a>
                     ))}
-        
-                    {signedInUser ? 
+
+                    {signedInUser ? (
                       <div className="mt-6">
                         <SignOut />
                       </div>
-                        :
-                    <div className="mt-6">
-                      <a
-                        href="https://www.tickettailor.com/events/dataengbytes"
-                        className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700"
-                      >
-                        Get Tickets
-                      </a>
-                    </div>
-                    }
+                    ) : (
+                      <div className="mt-6">
+                        <a
+                          href="https://www.tickettailor.com/events/dataengbytes"
+                          className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+                        >
+                          Get Tickets
+                        </a>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -429,5 +339,5 @@ export default function Navigation(props) {
         </>
       )}
     </Popover>
-  )
+  );
 }

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -38,19 +38,37 @@ const aboutUs = [
   },
 ];
 
-const conferenceLinks = [
+const currentConferenceLinks = [
   {
-    name: "Speakers",
+    name: "2022 Speakers",
+    description: "Our awesome speakers for 2022!",
+    href: "/#speakers",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
+  },
+  {
+    name: "2022 Schedule",
+    description: "Our awesome schedule for 2022!",
+    href: "/#schedule",
+    icon: <FontAwesomeIcon icon={faMeetup} />,
+  },
+]
+
+// TODO this is a hack. The current mobile dropdown does not close on href: "/#speakers" to the same page.
+const mobileCurrentConferenceLinks = [
+  {
+    name: "2022 Speakers",
     description: "Our awesome speakers for 2022!",
     href: "/conference/speakers",
     icon: <FontAwesomeIcon icon={faMeetup} />,
   },
   {
-    name: "Schedule",
+    name: "2022 Schedule",
     description: "Our awesome schedule for 2022!",
     href: "/conference/schedule",
     icon: <FontAwesomeIcon icon={faMeetup} />,
   },
+]
+const conferenceLinks = [
   {
     name: "2020",
     description: "Our first ever conference!",
@@ -98,7 +116,15 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
 
-function NavbarItem(label, list) {
+// Dropdown item definition
+// TODO style fix: line up the drop down box with the nav bar height.
+/**
+ * 
+ * @param {label} Main label that shows up on the NavBar.
+ * @param {list} (Optional) Dropdown list items. 
+ * @returns 
+ */
+function NavbarItem(label, list=[]) {
   return (
     <Popover className="relative">
       {({ open }) => (
@@ -180,7 +206,7 @@ export default function Navigation(props) {
   // useEffect(() => setUser(useState(null)), [])
 
   return (
-    <Popover className="relative bg-white">
+    <Popover className="relative bg-white z-10">
       {({ open }) => (
         <>
           <div className="max-w-7xl mx-auto px-4 sm:px-6">
@@ -196,6 +222,8 @@ export default function Navigation(props) {
                 </a>
               </div>
               <div></div>
+              {/* What's this for? If we're not using it, better not have it */}
+              {/* If we are to use it, please leave comments what it's planned for w/ TODO comments. */}
               <div className="-mr-2 -my-2 md:hidden">
                 <Popover.Button className="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
                   <span className="sr-only">Open menu</span>
@@ -204,7 +232,14 @@ export default function Navigation(props) {
               </div>
 
               <Popover.Group as="nav" className="hidden md:flex space-x-10">
-                { NavbarItem("Conference", conferenceLinks) }
+                { currentConferenceLinks.map((conference) => (
+                  <a
+                    href={conference.href}
+                    className="text-base font-medium text-gray-500 hover:text-gray-900"
+                  >
+                    {conference.name}
+                  </a>
+                ))}
                 <a
                   href="/blogs"
                   className="text-base font-medium text-gray-500 hover:text-gray-900"
@@ -218,6 +253,7 @@ export default function Navigation(props) {
                   Sponsor Us
                 </a>
                 { NavbarItem("About Us", aboutUs) }
+                { NavbarItem("Past Conferences", conferenceLinks) }
                 { NavbarItem("Meetups", meetupLinks) }
               </Popover.Group>
               {signedInUser ? (
@@ -276,6 +312,15 @@ export default function Navigation(props) {
                 </div>
                 <div className="py-6 px-5 space-y-6">
                   <div className="grid grid-cols-2 gap-y-4 gap-x-8">
+                    {mobileCurrentConferenceLinks.map((item) => (
+                      <a
+                        key={item.name}
+                        href={item.href}
+                        className="text-base font-medium text-gray-900 hover:text-gray-700"
+                      >
+                        {item.name}
+                      </a>
+                    ))}
                     {conferenceLinks.map((item) => (
                       <a
                         key={item.name}


### PR DESCRIPTION
Refactored NavBar items so styling can be consistent, and future maintenance easier since they use the same template.

Reordered the navbar options so current conference info is more prominent. `Blogs` is now under About Us.
Before:
<img width="1282" alt="Screen Shot 2022-08-21 at 11 06 38 am" src="https://user-images.githubusercontent.com/11097906/185771211-c29d15f8-a8f4-438f-be19-f908d22ab841.png">
After:
<img width="1308" alt="Screen Shot 2022-08-21 at 11 08 44 am" src="https://user-images.githubusercontent.com/11097906/185771214-89fe3889-a5df-4c69-b9d1-72966e0edc41.png">

Fixed this mobile bug, made NavBar positioned above other components using z-10 placement.
Before on `Speakers` page:
<img width="333" alt="Screen Shot 2022-08-21 at 11 06 15 am" src="https://user-images.githubusercontent.com/11097906/185771274-823f88d0-bdae-4531-bb9f-dd175db8ab32.png">
After:
<img width="453" alt="Screen Shot 2022-08-21 at 11 16 38 am" src="https://user-images.githubusercontent.com/11097906/185771306-18819be5-06a5-4999-8265-113733e9ffd2.png">




